### PR TITLE
Adds script to predict URLs

### DIFF
--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -14,8 +14,6 @@
    "metadata": {},
    "source": [
     "#### TO-DO\n",
-    "- complete testing\n",
-    "- confirm whether or not datatypes that require keys ever have duplicate keys. My guess is no and not worth testing\n",
     "- Might need requirements.txt and how to code for that, using % to install packages"
    ]
   },
@@ -29,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "id": "d891278c",
    "metadata": {},
    "outputs": [],
@@ -59,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -67,7 +65,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2020/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n"
+      "Valid URL found: https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2025/FeatureServer/0. Adding to OPD_Source_table.\n",
+      "Added to OPD_Source_table: https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2025/FeatureServer/0\n"
      ]
     }
    ],
@@ -97,31 +96,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "074420b7",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "\"None of [DatetimeIndex(['2023-08-15', '2025-04-06', '2025-02-17', '2023-07-06',\\n               '2024-03-16', '2024-07-28', '2024-07-28', '2024-07-28',\\n               '2025-04-06', '2025-04-06', '2025-04-06', '2025-04-06',\\n               '2025-04-06', '2023-07-06', '2023-07-06', '2024-03-03',\\n               '2024-03-03', '2025-04-06', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-02-17', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2023-07-06', '2025-04-13', '2023-07-06',\\n               '2023-08-13', '2025-04-13', '2023-07-06', '2025-04-13',\\n               '2025-04-13', '2023-08-15', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2024-03-03',\\n               '2024-06-24', '2025-04-13', '2024-05-10', '2025-02-17',\\n               '2024-03-23', '2025-02-17', '2025-04-13', '2025-04-18',\\n               '2025-04-18', '2025-04-18', '2023-07-07', '2025-04-18',\\n               '2023-07-07', '2023-07-07', '2023-07-07', '2025-03-09',\\n               '2024-05-31', '2024-05-31'],\\n              dtype='datetime64[ns]', freq=None)] are in the [index]\"",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mprediction_funcs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mauto_update_sources\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\opd-data\\python\\predict_urls\\prediction_funcs.py:228\u001b[39m, in \u001b[36mauto_update_sources\u001b[39m\u001b[34m(outdated_days, verbose)\u001b[39m\n\u001b[32m    226\u001b[39m composite_key = [\u001b[33m'\u001b[39m\u001b[33mState\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mSourceName\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mAgencyFull\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mTableType\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m    227\u001b[39m df[\u001b[33m\"\u001b[39m\u001b[33mlast_coverage_check_dt\u001b[39m\u001b[33m\"\u001b[39m] = pd.to_datetime(df[\u001b[33m\"\u001b[39m\u001b[33mlast_coverage_check\u001b[39m\u001b[33m\"\u001b[39m], errors=\u001b[33m\"\u001b[39m\u001b[33mcoerce\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m--> \u001b[39m\u001b[32m228\u001b[39m max_df = \u001b[43mdf\u001b[49m\u001b[43m.\u001b[49m\u001b[43mloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43mdf\u001b[49m\u001b[43m.\u001b[49m\u001b[43mgroupby\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcomposite_key\u001b[49m\u001b[43m)\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mlast_coverage_check_dt\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmax\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m]\u001b[49m\n\u001b[32m    229\u001b[39m \u001b[38;5;66;03m# 5. Check for outdated sources \u001b[39;00m\n\u001b[32m    230\u001b[39m \u001b[38;5;66;03m# Parse last_coverage_check as datetime #TODO it is not getting max for grouped rows. What's going on here?\u001b[39;00m\n\u001b[32m    231\u001b[39m \n\u001b[32m    232\u001b[39m \u001b[38;5;66;03m# Keep rows where last_coverage_check_dt is NaT or older than outdated_days\u001b[39;00m\n\u001b[32m    233\u001b[39m current_date = datetime.now()\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1191\u001b[39m, in \u001b[36m_LocationIndexer.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   1189\u001b[39m maybe_callable = com.apply_if_callable(key, \u001b[38;5;28mself\u001b[39m.obj)\n\u001b[32m   1190\u001b[39m maybe_callable = \u001b[38;5;28mself\u001b[39m._check_deprecated_callable_usage(key, maybe_callable)\n\u001b[32m-> \u001b[39m\u001b[32m1191\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_getitem_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmaybe_callable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m=\u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1420\u001b[39m, in \u001b[36m_LocIndexer._getitem_axis\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1417\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(key, \u001b[33m\"\u001b[39m\u001b[33mndim\u001b[39m\u001b[33m\"\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m key.ndim > \u001b[32m1\u001b[39m:\n\u001b[32m   1418\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mCannot index with multidimensional key\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m-> \u001b[39m\u001b[32m1420\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_getitem_iterable\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m=\u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1422\u001b[39m \u001b[38;5;66;03m# nested tuple slicing\u001b[39;00m\n\u001b[32m   1423\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_nested_tuple(key, labels):\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1360\u001b[39m, in \u001b[36m_LocIndexer._getitem_iterable\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1357\u001b[39m \u001b[38;5;28mself\u001b[39m._validate_key(key, axis)\n\u001b[32m   1359\u001b[39m \u001b[38;5;66;03m# A collection of keys\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1360\u001b[39m keyarr, indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_get_listlike_indexer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1361\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.obj._reindex_with_indexers(\n\u001b[32m   1362\u001b[39m     {axis: [keyarr, indexer]}, copy=\u001b[38;5;28;01mTrue\u001b[39;00m, allow_dups=\u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[32m   1363\u001b[39m )\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1558\u001b[39m, in \u001b[36m_LocIndexer._get_listlike_indexer\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1555\u001b[39m ax = \u001b[38;5;28mself\u001b[39m.obj._get_axis(axis)\n\u001b[32m   1556\u001b[39m axis_name = \u001b[38;5;28mself\u001b[39m.obj._get_axis_name(axis)\n\u001b[32m-> \u001b[39m\u001b[32m1558\u001b[39m keyarr, indexer = \u001b[43max\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_get_indexer_strict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1560\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m keyarr, indexer\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexes\\base.py:6200\u001b[39m, in \u001b[36mIndex._get_indexer_strict\u001b[39m\u001b[34m(self, key, axis_name)\u001b[39m\n\u001b[32m   6197\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   6198\u001b[39m     keyarr, indexer, new_indexer = \u001b[38;5;28mself\u001b[39m._reindex_non_unique(keyarr)\n\u001b[32m-> \u001b[39m\u001b[32m6200\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_raise_if_missing\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkeyarr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mindexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   6202\u001b[39m keyarr = \u001b[38;5;28mself\u001b[39m.take(indexer)\n\u001b[32m   6203\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Index):\n\u001b[32m   6204\u001b[39m     \u001b[38;5;66;03m# GH 42790 - Preserve name from an Index\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexes\\base.py:6249\u001b[39m, in \u001b[36mIndex._raise_if_missing\u001b[39m\u001b[34m(self, key, indexer, axis_name)\u001b[39m\n\u001b[32m   6247\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m nmissing:\n\u001b[32m   6248\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m nmissing == \u001b[38;5;28mlen\u001b[39m(indexer):\n\u001b[32m-> \u001b[39m\u001b[32m6249\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNone of [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mkey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m] are in the [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00maxis_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m]\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m   6251\u001b[39m     not_found = \u001b[38;5;28mlist\u001b[39m(ensure_index(key)[missing_mask.nonzero()[\u001b[32m0\u001b[39m]].unique())\n\u001b[32m   6252\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnot_found\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m not in index\u001b[39m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"None of [DatetimeIndex(['2023-08-15', '2025-04-06', '2025-02-17', '2023-07-06',\\n               '2024-03-16', '2024-07-28', '2024-07-28', '2024-07-28',\\n               '2025-04-06', '2025-04-06', '2025-04-06', '2025-04-06',\\n               '2025-04-06', '2023-07-06', '2023-07-06', '2024-03-03',\\n               '2024-03-03', '2025-04-06', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-02-17', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2023-07-06', '2025-04-13', '2023-07-06',\\n               '2023-08-13', '2025-04-13', '2023-07-06', '2025-04-13',\\n               '2025-04-13', '2023-08-15', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2024-03-03',\\n               '2024-06-24', '2025-04-13', '2024-05-10', '2025-02-17',\\n               '2024-03-23', '2025-02-17', '2025-04-13', '2025-04-18',\\n               '2025-04-18', '2025-04-18', '2023-07-07', '2025-04-18',\\n               '2023-07-07', '2023-07-07', '2023-07-07', '2025-03-09',\\n               '2024-05-31', '2024-05-31'],\\n              dtype='datetime64[ns]', freq=None)] are in the [index]\""
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "prediction_funcs.auto_update_sources()"
+    "prediction_funcs.auto_update_sources(\n",
+    "    # outdated_days=30 # unspecified defaults to last year\n",
+    "    # ,\n",
+    "    # verbose=True\n",
+    ")"
    ]
   }
  ],

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -16,8 +16,7 @@
     "#### TO-DO\n",
     "- complete testing\n",
     "- Might need requirements.txt and how to code for that, using % to install packages\n",
-    "- add check if URL already in source table\n",
-    "- Is there a get data loader function?"
+    "- add check if URL already in source table"
    ]
   },
   {
@@ -30,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 1,
    "id": "d891278c",
    "metadata": {},
    "outputs": [],
@@ -48,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -56,19 +55,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0 (status: ArcGIS check)\n",
-      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0\n"
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0\n",
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0\n",
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0\n",
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0: not valid. Skipping.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0'"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -79,10 +75,11 @@
     "    \"Agency\": \"EXPD\",\n",
     "    \"AgencyFull\": \"Example Police Department\",\n",
     "    \"TableType\": \"Arrests\",\n",
-    "    \"DataType\": \"ArcGIS\"\n",
+    "    \"DataType\": \"ArcGIS\",\n",
+    "    \"date_field\": \"calldatetime\" \n",
     "}\n",
     "\n",
-    "prediction_funcs.try_url_years(url, n_years=3, forward=True, extra_fields=extra_fields)"
+    "prediction_funcs.try_url_years(url, forward=True, spreadsheet_fields=spreadsheet_fields)"
    ]
   },
   {

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -16,7 +16,8 @@
     "#### TO-DO\n",
     "- complete testing\n",
     "- Might need requirements.txt and how to code for that, using % to install packages\n",
-    "- add check if URL already in source table"
+    "- add check if URL already in source table\n",
+    "- Is there a get data loader function?"
    ]
   },
   {
@@ -29,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "d891278c",
    "metadata": {},
    "outputs": [],
@@ -47,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -55,14 +56,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2026_csv/FeatureServer/0: not valid (status: ArcGIS check)\n",
-      "No valid URL found.\n"
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0 (status: ArcGIS check)\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2025_csv/FeatureServer/0\"\n",
-    "extra_fields = {\n",
+    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2016_csv/FeatureServer/0\"\n",
+    "spreadsheet_fields = {\n",
     "    \"State\": \"CA\",\n",
     "    \"SourceName\": \"Example PD\",\n",
     "    \"Agency\": \"EXPD\",\n",
@@ -71,7 +82,7 @@
     "    \"DataType\": \"ArcGIS\"\n",
     "}\n",
     "\n",
-    "prediction_funcs.try_url_years(url, n_years=1, forward=True, extra_fields=extra_fields)"
+    "prediction_funcs.try_url_years(url, n_years=3, forward=True, extra_fields=extra_fields)"
    ]
   },
   {

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -15,8 +15,7 @@
    "source": [
     "#### TO-DO\n",
     "- complete testing\n",
-    "- Might need requirements.txt and how to code for that, using % to install packages\n",
-    "- add check if URL already in source table"
+    "- Might need requirements.txt and how to code for that, using % to install packages"
    ]
   },
   {
@@ -55,15 +54,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
-      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0\n",
-      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
-      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0\n",
-      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
-      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0\n",
-      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
-      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0\n",
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0: not valid. Skipping.\n"
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0 in spreadsheet but no longer valid. Removing and logging as deleted.\n"
      ]
     }
    ],
@@ -76,10 +71,10 @@
     "    \"AgencyFull\": \"Example Police Department\",\n",
     "    \"TableType\": \"Arrests\",\n",
     "    \"DataType\": \"ArcGIS\",\n",
-    "    \"date_field\": \"calldatetime\" \n",
+    "    # \"date_field\": \"calldatetime\" \n",
     "}\n",
     "\n",
-    "prediction_funcs.try_url_years(url, forward=True, spreadsheet_fields=spreadsheet_fields)"
+    "prediction_funcs.try_url_years(url, forward=True, verbose=True, spreadsheet_fields=spreadsheet_fields)"
    ]
   },
   {
@@ -88,20 +83,7 @@
    "id": "7f8fb34c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import requests"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a5328b42",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resp = requests.head(url, allow_redirects=False, timeout=10)\n",
-    "resp.status_code"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -45,8 +45,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "aab1874e",
+   "metadata": {},
+   "source": [
+    "**Additional spreadsheet fields:**\n",
+    "\"Description\", \"source_url\", \"readme\", \"date_field\",\n",
+    "\"agency_field\", \"min_version\", \"query\"\n",
+    "\n",
+    "The `try_urls_years` function auto-fills the spreadsheet's \"URL\", \"Year\",\"last_coverage_check\", \"coverage_start\", and \"coverage_end\"."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -58,32 +70,25 @@
       "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
       "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
       "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0 in spreadsheet but no longer valid. Removing and logging as deleted.\n"
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0: not valid. Skipping.\n"
      ]
     }
    ],
    "source": [
     "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2016_csv/FeatureServer/0\"\n",
-    "spreadsheet_fields = {\n",
+    "spreadsheet_fields = { #required fields\n",
     "    \"State\": \"CA\",\n",
     "    \"SourceName\": \"Example PD\",\n",
     "    \"Agency\": \"EXPD\",\n",
     "    \"AgencyFull\": \"Example Police Department\",\n",
     "    \"TableType\": \"Arrests\",\n",
-    "    \"DataType\": \"ArcGIS\",\n",
-    "    # \"date_field\": \"calldatetime\" \n",
+    "    \"DataType\": \"ArcGIS\"\n",
+    "    # below required if \"DataType\" = \"Carto\" or \"Ckan\"\n",
+    "    # , dataset_id\": \"example-dataset-id\" \n",
     "}\n",
     "\n",
     "prediction_funcs.try_url_years(url, forward=True, verbose=True, spreadsheet_fields=spreadsheet_fields)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7f8fb34c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -15,6 +15,7 @@
    "source": [
     "#### TO-DO\n",
     "- complete testing\n",
+    "- confirm whether or not datatypes that require keys ever have duplicate keys. My guess is no and not worth testing\n",
     "- Might need requirements.txt and how to code for that, using % to install packages"
    ]
   },
@@ -28,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "d891278c",
    "metadata": {},
    "outputs": [],
@@ -58,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -66,16 +67,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
-      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0: not valid. Skipping.\n"
+      "https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2020/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n"
      ]
     }
    ],
    "source": [
-    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2016_csv/FeatureServer/0\"\n",
+    "url = \"https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2024/FeatureServer/0\"\n",
     "spreadsheet_fields = { #required fields\n",
     "    \"State\": \"CA\",\n",
     "    \"SourceName\": \"Example PD\",\n",
@@ -87,7 +84,7 @@
     "    # , dataset_id\": \"example-dataset-id\" \n",
     "}\n",
     "\n",
-    "prediction_funcs.try_url_years(url, forward=True, verbose=True, spreadsheet_fields=spreadsheet_fields)"
+    "prediction_funcs.try_url_years(url, n_years=1, verbose=True, spreadsheet_fields=spreadsheet_fields)"
    ]
   },
   {
@@ -100,12 +97,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "074420b7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "\"None of [DatetimeIndex(['2023-08-15', '2025-04-06', '2025-02-17', '2023-07-06',\\n               '2024-03-16', '2024-07-28', '2024-07-28', '2024-07-28',\\n               '2025-04-06', '2025-04-06', '2025-04-06', '2025-04-06',\\n               '2025-04-06', '2023-07-06', '2023-07-06', '2024-03-03',\\n               '2024-03-03', '2025-04-06', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-02-17', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2023-07-06', '2025-04-13', '2023-07-06',\\n               '2023-08-13', '2025-04-13', '2023-07-06', '2025-04-13',\\n               '2025-04-13', '2023-08-15', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2024-03-03',\\n               '2024-06-24', '2025-04-13', '2024-05-10', '2025-02-17',\\n               '2024-03-23', '2025-02-17', '2025-04-13', '2025-04-18',\\n               '2025-04-18', '2025-04-18', '2023-07-07', '2025-04-18',\\n               '2023-07-07', '2023-07-07', '2023-07-07', '2025-03-09',\\n               '2024-05-31', '2024-05-31'],\\n              dtype='datetime64[ns]', freq=None)] are in the [index]\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mprediction_funcs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mauto_update_sources\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\opd-data\\python\\predict_urls\\prediction_funcs.py:228\u001b[39m, in \u001b[36mauto_update_sources\u001b[39m\u001b[34m(outdated_days, verbose)\u001b[39m\n\u001b[32m    226\u001b[39m composite_key = [\u001b[33m'\u001b[39m\u001b[33mState\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mSourceName\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mAgencyFull\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mTableType\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m    227\u001b[39m df[\u001b[33m\"\u001b[39m\u001b[33mlast_coverage_check_dt\u001b[39m\u001b[33m\"\u001b[39m] = pd.to_datetime(df[\u001b[33m\"\u001b[39m\u001b[33mlast_coverage_check\u001b[39m\u001b[33m\"\u001b[39m], errors=\u001b[33m\"\u001b[39m\u001b[33mcoerce\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m--> \u001b[39m\u001b[32m228\u001b[39m max_df = \u001b[43mdf\u001b[49m\u001b[43m.\u001b[49m\u001b[43mloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43mdf\u001b[49m\u001b[43m.\u001b[49m\u001b[43mgroupby\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcomposite_key\u001b[49m\u001b[43m)\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mlast_coverage_check_dt\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmax\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m]\u001b[49m\n\u001b[32m    229\u001b[39m \u001b[38;5;66;03m# 5. Check for outdated sources \u001b[39;00m\n\u001b[32m    230\u001b[39m \u001b[38;5;66;03m# Parse last_coverage_check as datetime #TODO it is not getting max for grouped rows. What's going on here?\u001b[39;00m\n\u001b[32m    231\u001b[39m \n\u001b[32m    232\u001b[39m \u001b[38;5;66;03m# Keep rows where last_coverage_check_dt is NaT or older than outdated_days\u001b[39;00m\n\u001b[32m    233\u001b[39m current_date = datetime.now()\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1191\u001b[39m, in \u001b[36m_LocationIndexer.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   1189\u001b[39m maybe_callable = com.apply_if_callable(key, \u001b[38;5;28mself\u001b[39m.obj)\n\u001b[32m   1190\u001b[39m maybe_callable = \u001b[38;5;28mself\u001b[39m._check_deprecated_callable_usage(key, maybe_callable)\n\u001b[32m-> \u001b[39m\u001b[32m1191\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_getitem_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmaybe_callable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m=\u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1420\u001b[39m, in \u001b[36m_LocIndexer._getitem_axis\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1417\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(key, \u001b[33m\"\u001b[39m\u001b[33mndim\u001b[39m\u001b[33m\"\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m key.ndim > \u001b[32m1\u001b[39m:\n\u001b[32m   1418\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mCannot index with multidimensional key\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m-> \u001b[39m\u001b[32m1420\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_getitem_iterable\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m=\u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1422\u001b[39m \u001b[38;5;66;03m# nested tuple slicing\u001b[39;00m\n\u001b[32m   1423\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_nested_tuple(key, labels):\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1360\u001b[39m, in \u001b[36m_LocIndexer._getitem_iterable\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1357\u001b[39m \u001b[38;5;28mself\u001b[39m._validate_key(key, axis)\n\u001b[32m   1359\u001b[39m \u001b[38;5;66;03m# A collection of keys\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1360\u001b[39m keyarr, indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_get_listlike_indexer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1361\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.obj._reindex_with_indexers(\n\u001b[32m   1362\u001b[39m     {axis: [keyarr, indexer]}, copy=\u001b[38;5;28;01mTrue\u001b[39;00m, allow_dups=\u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[32m   1363\u001b[39m )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexing.py:1558\u001b[39m, in \u001b[36m_LocIndexer._get_listlike_indexer\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1555\u001b[39m ax = \u001b[38;5;28mself\u001b[39m.obj._get_axis(axis)\n\u001b[32m   1556\u001b[39m axis_name = \u001b[38;5;28mself\u001b[39m.obj._get_axis_name(axis)\n\u001b[32m-> \u001b[39m\u001b[32m1558\u001b[39m keyarr, indexer = \u001b[43max\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_get_indexer_strict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1560\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m keyarr, indexer\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexes\\base.py:6200\u001b[39m, in \u001b[36mIndex._get_indexer_strict\u001b[39m\u001b[34m(self, key, axis_name)\u001b[39m\n\u001b[32m   6197\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   6198\u001b[39m     keyarr, indexer, new_indexer = \u001b[38;5;28mself\u001b[39m._reindex_non_unique(keyarr)\n\u001b[32m-> \u001b[39m\u001b[32m6200\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_raise_if_missing\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkeyarr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mindexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   6202\u001b[39m keyarr = \u001b[38;5;28mself\u001b[39m.take(indexer)\n\u001b[32m   6203\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Index):\n\u001b[32m   6204\u001b[39m     \u001b[38;5;66;03m# GH 42790 - Preserve name from an Index\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32md:\\Data Projects\\opd\\OPD-data\\.venv\\Lib\\site-packages\\pandas\\core\\indexes\\base.py:6249\u001b[39m, in \u001b[36mIndex._raise_if_missing\u001b[39m\u001b[34m(self, key, indexer, axis_name)\u001b[39m\n\u001b[32m   6247\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m nmissing:\n\u001b[32m   6248\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m nmissing == \u001b[38;5;28mlen\u001b[39m(indexer):\n\u001b[32m-> \u001b[39m\u001b[32m6249\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNone of [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mkey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m] are in the [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00maxis_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m]\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m   6251\u001b[39m     not_found = \u001b[38;5;28mlist\u001b[39m(ensure_index(key)[missing_mask.nonzero()[\u001b[32m0\u001b[39m]].unique())\n\u001b[32m   6252\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnot_found\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m not in index\u001b[39m\u001b[33m\"\u001b[39m)\n",
+      "\u001b[31mKeyError\u001b[39m: \"None of [DatetimeIndex(['2023-08-15', '2025-04-06', '2025-02-17', '2023-07-06',\\n               '2024-03-16', '2024-07-28', '2024-07-28', '2024-07-28',\\n               '2025-04-06', '2025-04-06', '2025-04-06', '2025-04-06',\\n               '2025-04-06', '2023-07-06', '2023-07-06', '2024-03-03',\\n               '2024-03-03', '2025-04-06', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-02-17', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2023-07-06', '2025-04-13', '2023-07-06',\\n               '2023-08-13', '2025-04-13', '2023-07-06', '2025-04-13',\\n               '2025-04-13', '2023-08-15', '2025-04-13', '2025-04-13',\\n               '2025-04-13', '2025-04-13', '2025-04-13', '2024-03-03',\\n               '2024-06-24', '2025-04-13', '2024-05-10', '2025-02-17',\\n               '2024-03-23', '2025-02-17', '2025-04-13', '2025-04-18',\\n               '2025-04-18', '2025-04-18', '2023-07-07', '2025-04-18',\\n               '2023-07-07', '2023-07-07', '2023-07-07', '2025-03-09',\\n               '2024-05-31', '2024-05-31'],\\n              dtype='datetime64[ns]', freq=None)] are in the [index]\""
+     ]
+    }
+   ],
    "source": [
-    "prediction_funcs.auto_update_sources(verbose=True)"
+    "prediction_funcs.auto_update_sources()"
    ]
   }
  ],

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -15,7 +15,8 @@
    "source": [
     "#### TO-DO\n",
     "- complete testing\n",
-    "- Might need requirements.txt and how to code for that, using % to install packages"
+    "- Might need requirements.txt and how to code for that, using % to install packages\n",
+    "- add check if URL already in source table"
    ]
   },
   {
@@ -28,39 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "ce3e171e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "sys.path.append(\"python/predict_urls\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "36441bb8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'d:\\\\Data Projects\\\\opd\\\\OPD-data\\\\opd-data\\\\python\\\\predict_urls'"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%pwd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "id": "d891278c",
    "metadata": {},
    "outputs": [],
@@ -78,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -86,23 +55,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0\n",
-      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0\n"
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2026_csv/FeatureServer/0: not valid (status: ArcGIS check)\n",
+      "No valid URL found.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0\"\n",
+    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2025_csv/FeatureServer/0\"\n",
     "extra_fields = {\n",
     "    \"State\": \"CA\",\n",
     "    \"SourceName\": \"Example PD\",\n",
@@ -117,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "7f8fb34c",
    "metadata": {},
    "outputs": [],
@@ -127,21 +86,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "a5328b42",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "200"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "resp = requests.head(url, allow_redirects=False, timeout=10)\n",
     "resp.status_code"

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -10,19 +10,57 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c654dfe",
+   "id": "43085b45",
    "metadata": {},
    "source": [
-    "#### TO-DO\n",
-    "- Might need requirements.txt and how to code for that, using % to install packages"
+    "## Environment pre-reqs\n",
+    "To install all required packages from `requirements.txt` in this folder, run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7430573c",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install -r requirements.txt"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "351efed0",
+   "id": "4e8a5367",
    "metadata": {},
    "source": [
-    "## Env and packages"
+    "Or, if you are using conda, you can create a new environment and install the requirements with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8e64df4",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "conda create -n opd-env python=3.11\n",
+    "conda activate opd-env\n",
+    "pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "896e49d8",
+   "metadata": {},
+   "source": [
+    "## Prediction functions"
    ]
   },
   {
@@ -32,6 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# import local script\n",
     "import prediction_funcs"
    ]
   },
@@ -96,8 +135,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "074420b7",
+   "execution_count": 3,
+   "id": "bcfdfc67",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "d891278c",
    "metadata": {},
    "outputs": [],
@@ -79,24 +79,95 @@
    "id": "9097e9a6",
    "metadata": {},
    "source": [
-    "## Example: Try to find a valid URL for a new year"
+    "## Find additional datasets from predictable URLs"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aab1874e",
+   "id": "63b190e4",
    "metadata": {},
    "source": [
-    "**Additional spreadsheet fields:**\n",
-    "\"Description\", \"source_url\", \"readme\", \"date_field\",\n",
-    "\"agency_field\", \"min_version\", \"query\"\n",
+    "#### `try_url_years` function\n",
+    "This function can be used to test for additional datasets from predictable URLs. Before adding a URL to the OPD Source Table, it will also assure it's not already there. If it is, it will retest if it returns data and appropriately updated the \"last_coverage_check\" field or remove deprecated URLs.\n",
     "\n",
-    "The `try_urls_years` function auto-fills the spreadsheet's \"URL\", \"Year\",\"last_coverage_check\", \"coverage_start\", and \"coverage_end\"."
+    "Fields required to add a new source to the OPD Source Table can be passed into the function in the \"spreadsheet_fields\" dict arg, as well as below additional fields as available.\n",
+    "\n",
+    "**Additional spreadsheet fields:**\n",
+    "\"Description\", \"source_url\", \"readme\", \"date_field\", \"agency_originated\", \"supplying_entity\", \"agency_field\", \"min_version\", \"query\"\n",
+    "\n",
+    "The `try_urls_years` function auto-fills the spreadsheet's \"URL\", \"Year\",\"last_coverage_check\", \"coverage_start\", and \"coverage_end\".\n",
+    "\n",
+    "**Function's args:**\n",
+    "- url: str. The URL to modify. *Required*.\n",
+    "- spreadsheet_fields: dict with fields to use for checking validity and adding to OPD_Source_table. *Required*.\n",
+    "- n_years: int or range. If int, tries n_years forward (or backward if forward=False). If range, uses as years to try. Optional, defaults to 5.\n",
+    "- forward: If n_years is int, direction to try. Optional, defaults to True.\n",
+    "- year_slice: tuple of (start, end) to slice the URL for the year. Optional, finds the first 4-digit year in the URL.\n",
+    "- verbose: If True, prints progress messages. Optional, defaults to False."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65b6481b",
+   "metadata": {},
+   "source": [
+    "#### Helpers\n",
+    "Current TableTypes:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
+   "id": "eb2903c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['ARRESTS', 'CALLS FOR SERVICE', 'INCIDENTS', 'EMPLOYEE', 'STOPS',\n",
+       "       'OFFICER-INVOLVED SHOOTINGS', 'POINTING WEAPON',\n",
+       "       'TRAFFIC CITATIONS', 'USE OF FORCE', 'CRASHES',\n",
+       "       'OFFICER-INVOLVED SHOOTINGS - INCIDENTS',\n",
+       "       'OFFICER-INVOLVED SHOOTINGS - OFFICERS',\n",
+       "       'OFFICER-INVOLVED SHOOTINGS - SUBJECTS', 'TRAFFIC STOPS',\n",
+       "       'DEATHS IN CUSTODY', 'USE OF FORCE - INCIDENTS',\n",
+       "       'USE OF FORCE - SUBJECTS/OFFICERS', 'STOPS - INCIDENTS',\n",
+       "       'STOPS - SUBJECTS', 'CITATIONS', 'COMPLAINTS',\n",
+       "       'USE OF FORCE - ADDITIONAL', 'VEHICLE PURSUITS',\n",
+       "       'COMPLAINTS - ALLEGATIONS', 'COMPLAINTS - BACKGROUND',\n",
+       "       'COMPLAINTS - BODY WORN CAMERA', 'COMPLAINTS - SUBJECTS',\n",
+       "       'CRASHES - INCIDENTS', 'CRASHES - SUBJECTS',\n",
+       "       'USE OF FORCE - OFFICERS', 'USE OF FORCE - SUBJECTS', 'LAWSUITS',\n",
+       "       'COMPLAINTS - OFFICERS', 'PEDESTRIAN STOPS', 'FIELD CONTACTS',\n",
+       "       'TRAFFIC WARNINGS', 'CRASHES - NONMOTORIST',\n",
+       "       'DISCIPLINARY RECORDS', 'COMPLAINTS - PENALTIES',\n",
+       "       'CRASHES - VEHICLES', 'TRAFFIC STOPS - INCIDENTS',\n",
+       "       'TRAFFIC STOPS - SUBJECTS', 'COMPLAINTS - SUBJECTS/OFFICERS',\n",
+       "       'INCIDENTS - INCIDENTS', 'INCIDENTS - SUBJECTS',\n",
+       "       'PEDESTRIAN CITATIONS', 'SEARCHES', 'WARNINGS'], dtype=object)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "opd = pd.read_csv(\"../../opd_source_table.csv\")\n",
+    "opd[\"TableType\"].unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4bf0aa1",
+   "metadata": {},
+   "source": [
+    "### The function with args template for use :)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "bcfdfc67",
    "metadata": {},
    "outputs": [
@@ -104,25 +175,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Valid URL found: https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2025/FeatureServer/0. Adding to OPD_Source_table.\n",
-      "Added to OPD_Source_table: https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2025/FeatureServer/0\n"
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2014_csv/FeatureServer/0: not valid. Skipping.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2015_csv/FeatureServer/0: not valid. Skipping.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2016_csv/FeatureServer/0: not valid. Skipping.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2019_csv/FeatureServer/0 already in spreadsheet and valid. Updated last_coverage_check.\n",
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0. Adding to OPD_Source_table.\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2020_csv/FeatureServer/0\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2021_csv/FeatureServer/0 in spreadsheet but no longer valid. Removing and logging as deleted.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2022_csv/FeatureServer/0: not valid. Skipping.\n",
+      "https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2023_csv/FeatureServer/0: not valid. Skipping.\n"
      ]
     }
    ],
    "source": [
-    "url = \"https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Sacramento_Call_for_Service_Data_2024/FeatureServer/0\"\n",
-    "spreadsheet_fields = { #required fields\n",
-    "    \"State\": \"CA\",\n",
-    "    \"SourceName\": \"Example PD\",\n",
-    "    \"Agency\": \"EXPD\",\n",
-    "    \"AgencyFull\": \"Example Police Department\",\n",
-    "    \"TableType\": \"Arrests\",\n",
+    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2013_csv/FeatureServer/0\"\n",
+    "spreadsheet_fields = {\n",
+    "    # required fields\n",
+    "    \"State\": \"Maryland\",\n",
+    "    \"SourceName\": \"Baltimore\",\n",
+    "    \"Agency\": \"BPD\",\n",
+    "    \"AgencyFull\": \"Baltimore Police Department\",\n",
+    "    \"TableType\": \"CALLS FOR SERVICE\",\n",
     "    \"DataType\": \"ArcGIS\"\n",
-    "    # below required if \"DataType\" = \"Carto\" or \"Ckan\"\n",
-    "    # , dataset_id\": \"example-dataset-id\" \n",
+    "    # below required if \"DataType\" = \"Carto\", \"Ckan\", or \"Socrata\"\n",
+    "    # , dataset_id\": \"example-dataset-id\" # this is unlikely to be the same for multiple years, but leaving for completeness and future improvements\n",
+    "    # additional fields as needed\n",
+    "    , \"source_url\": \"https://services1.arcgis.com/UWYHeuuJISiGmgXx/ArcGIS/rest/services/911_2013_2022/FeatureServer\"\n",
+    "    , \"agency_originated\": \"yes\" \n",
     "}\n",
     "\n",
-    "prediction_funcs.try_url_years(url, n_years=1, verbose=True, spreadsheet_fields=spreadsheet_fields)"
+    "prediction_funcs.try_url_years(url, n_years=10, verbose=True, spreadsheet_fields=spreadsheet_fields)"
    ]
   },
   {
@@ -130,7 +214,20 @@
    "id": "104ac633",
    "metadata": {},
    "source": [
-    "## Example: Automatically update all outdated sources"
+    "## Check all OPD Sources for new predictable URLs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab77aa05",
+   "metadata": {},
+   "source": [
+    "#### `auto_update_sources` function\n",
+    "This function does a lot more of the leg work for you, by simply checking the existing sources for predictable URLs that may have new datasets available. It does so by automatically looking for where the \"last_coverage_check\" date is last year or older, but you can use the `outdated_days` arg to check more recently checked sources.\n",
+    "\n",
+    "Note it only checks forward, as it first groups by fields 'State', 'SourceName', 'AgencyFull', and 'TableType' as a composite key, and gets the max Year to test forward from, stopping at current year.\n",
+    "\n",
+    "The function also assumes all other fields for the new URLs, with the exception of date-related fields, can be duplicated from the latest record. Please confirm any descriptions, readmes, etc, are still relevant. "
    ]
   },
   {
@@ -138,7 +235,15 @@
    "execution_count": 3,
    "id": "bcfdfc67",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checked 15 sources for new URLs, found 4 new sources.\n"
+     ]
+    }
+   ],
    "source": [
     "prediction_funcs.auto_update_sources(\n",
     "    # outdated_days=30 # unspecified defaults to last year\n",

--- a/python/predict_urls/predict_urls.ipynb
+++ b/python/predict_urls/predict_urls.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "00f083d7",
+   "metadata": {},
+   "source": [
+    "# How-to: Predict and update URLs for OPD data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c654dfe",
+   "metadata": {},
+   "source": [
+    "#### TO-DO\n",
+    "- complete testing\n",
+    "- Might need requirements.txt and how to code for that, using % to install packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "351efed0",
+   "metadata": {},
+   "source": [
+    "## Env and packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ce3e171e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"python/predict_urls\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "36441bb8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'d:\\\\Data Projects\\\\opd\\\\OPD-data\\\\opd-data\\\\python\\\\predict_urls'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d891278c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import prediction_funcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9097e9a6",
+   "metadata": {},
+   "source": [
+    "## Example: Try to find a valid URL for a new year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bcfdfc67",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valid URL found: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0\n",
+      "Added to OPD_Source_table: https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2018_csv/FeatureServer/0'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "url = \"https://opendata.baltimorecity.gov/egis/rest/services/Hosted/911_Calls_For_Service_2017_csv/FeatureServer/0\"\n",
+    "extra_fields = {\n",
+    "    \"State\": \"CA\",\n",
+    "    \"SourceName\": \"Example PD\",\n",
+    "    \"Agency\": \"EXPD\",\n",
+    "    \"AgencyFull\": \"Example Police Department\",\n",
+    "    \"TableType\": \"Arrests\",\n",
+    "    \"DataType\": \"ArcGIS\"\n",
+    "}\n",
+    "\n",
+    "prediction_funcs.try_url_years(url, n_years=1, forward=True, extra_fields=extra_fields)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7f8fb34c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a5328b42",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp = requests.head(url, allow_redirects=False, timeout=10)\n",
+    "resp.status_code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "104ac633",
+   "metadata": {},
+   "source": [
+    "## Example: Automatically update all outdated sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "074420b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prediction_funcs.auto_update_sources(verbose=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -67,6 +67,18 @@ def is_data_available(data_type, url, spreadsheet_fields):
     except Exception as e:
         return False
 
+def find_valid_url_for_year(url, year, year_str, data_type, spreadsheet_fields):
+    """
+    Returns (is_valid, new_url, coverage_start, coverage_end)
+    """
+    new_url = url.replace(year_str, str(year), 1)
+    try:
+        valid = is_data_available(data_type, new_url, spreadsheet_fields)
+    except Exception as e:
+        valid = False
+    return valid, new_url
+
+##TODO - add limit so it never tests past current year
 def try_url_years(
     url: str,
     n_years = 5,
@@ -111,23 +123,20 @@ def try_url_years(
             years_to_try = range(year - 1, year - n_years - 1, -1)
     else:
         raise ValueError("n_years must be an int or a range.")
-
+    
+    df = pd.read_csv(OPD_SOURCE_TABLE)
+    deleted_df = pd.read_csv(DELETED_TABLE)
+    current_year = datetime.now().year    
+    
     for y in years_to_try:
-        df = pd.read_csv(OPD_SOURCE_TABLE)
-        deleted_df = pd.read_csv(DELETED_TABLE)
         new_url = url.replace(year_str, str(y), 1)
-         # Check if URL is already in the spreadsheet
+        # Check if URL is already in the spreadsheet
         in_spreadsheet = (df["URL"] == new_url).any()
         if in_spreadsheet:
             idx = df.index[df["URL"] == new_url][0]
             row = df.loc[idx]
             # Test if still valid
-            try:
-                valid = is_data_available(data_type, new_url, spreadsheet_fields)
-            except Exception as e:
-                if verbose:
-                    print(f"Error fetching {new_url}: \n {e}")
-                continue
+            valid, _ = find_valid_url_for_year(url, y, year_str, data_type, spreadsheet_fields)
             if valid:
                 # Update last_coverage_check and coverage dates
                 df.at[idx, "last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
@@ -139,7 +148,7 @@ def try_url_years(
                 # Remove from spreadsheet, add to deleted
                 if verbose:
                     print(f"{new_url} in spreadsheet but no longer valid. Removing and logging as deleted.")
-                # TODO - fix fields for deleted_table
+                # TODO - fix fields for deleted_table... *days later* I don't remember what I meant here.
                 removed_row = df.loc[[idx]].copy()
                 deleted_fields = [
                     "OPD Status","State","SourceName","Agency","AgencyFull","TableType","Year","Error",
@@ -161,12 +170,7 @@ def try_url_years(
                 deleted_df.to_csv(DELETED_TABLE, index=False)
                 continue
         else:
-            try:
-                valid = is_data_available(data_type, new_url, spreadsheet_fields)
-            except Exception as e:
-                if verbose:
-                    print(f"Error fetching {new_url}: \n {e}")
-                continue
+            valid, new_url = find_valid_url_for_year(url, y, year_str, data_type, spreadsheet_fields)
             if valid:
                 if verbose:
                     print(f"Valid URL found: {new_url}. Adding to OPD_Source_table.")
@@ -182,7 +186,10 @@ def try_url_years(
                 row["Year"] = str(y)
                 row["last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
                 row["coverage_start"] = f"01/01/{y}"
-                row["coverage_end"] = f"12/31/{y}"
+                if y == current_year:
+                    row["coverage_end"] = datetime.now().strftime("%m/%d/%Y")
+                else:
+                    row["coverage_end"] = f"12/31/{y}"
                 if spreadsheet_fields:
                     for k, v in spreadsheet_fields.items():
                         if k in row:
@@ -200,80 +207,67 @@ def try_url_years(
     return None
 
 def auto_update_sources(
-    outdated_days=30,
+    outdated_days=365,
     verbose=False
 ):
     """
     Automatically check for new data by incrementing year in URLs for testable sources.
 
     Args:
-        source_table_path (str or Path): Path to OPD_Source_table.csv.
-        tracking_table_path (str or Path): Path to police_data_source_tracking.csv.
         outdated_days (int): How many days before a source is considered outdated.
         verbose (bool): Print progress and results.
     Returns:
         list: List of new URLs added.
     """
-    # 1. Load tables
+    # 1. Load table and parse last_coverage_check as datetime
     df = pd.read_csv(OPD_SOURCE_TABLE)
-    # 2. Filter by DataType (use all testable types in LOADER_MAP)
-    testable_types = list(LOADER_MAP.keys())
-    df = df[df["DataType"].str.lower().isin([t.lower() for t in testable_types])]
-    # 3. Filter URLs with exactly one 4-digit year
-    df = df[df["URL"].str.contains(r"\d{4}", regex=True)]
-    df = df[df["URL"].str.count(r"\d{4}") == 1]
-    # 4. Group by composite key and get max last checked date
+    df["last_coverage_check_dt"] = pd.to_datetime(df["last_coverage_check"], errors="coerce")
+    # 2. Group by composite key and get max last checked date
     composite_key = ['State', 'SourceName', 'AgencyFull', 'TableType']
-    max_df = df.loc[df.groupby(composite_key)["last_coverage_check"].idxmax()]
-    # 5. Check for outdated sources 
-    # Parse last_coverage_check as datetime
-    max_df["last_coverage_check_dt"] = pd.to_datetime(max_df["last_coverage_check"], errors="coerce")
-    last_year = datetime.now().year - 1
-    # Keep rows where last_coverage_check is before Jan 1 of this year
-    to_test = max_df[max_df["last_coverage_check_dt"].dt.year <= last_year]
-   
-   
-    ## STOPPED HERE TODO
-    # 6. Test URLs for 
-    new_urls = []
-    for idx in outdated:
-        row = df.loc[idx]
-        url = row["URL"]
-        data_type = row["DataType"].lower()
+    max_df = df.loc[df.groupby(composite_key)["Year"].idxmax()]
+    # 3. Filter URLs with exactly one 4-digit year
+    max_df = max_df[max_df["URL"].str.contains(r"\d{4}", regex=True)]
+    max_df = max_df[max_df["URL"].str.count(r"\d{4}") == 1]
+    # Keep rows where last_coverage_check_dt is NaT or older than outdated_days
+    current_date = datetime.now()
+    if outdated_days is not None:
+        cutoff_date = current_date - pd.Timedelta(days=outdated_days)
+        to_test = max_df[max_df["last_coverage_check_dt"] <= cutoff_date]
+    else:
+        last_year = current_date.year - 1
+        to_test = max_df[max_df["last_coverage_check_dt"].dt.year <= last_year]
+    to_test = to_test.drop(columns=["last_coverage_check_dt"])
+    # 6. For each outdated row, try to find new URLs by incrementing year using try_url_years
+    current_year = datetime.now().year
+    for row in to_test.itertuples(index=False):
+        url = row.URL
+        data_type = row.DataType.lower()
         year_match = re.search(r"\d{4}", url)
         if not year_match:
             continue
         year_str = year_match.group()
         year = int(year_str)
-        # Try next year
-        new_year = year + 1
-        new_url = url.replace(year_str, str(new_year), 1)
-        # Prepare spreadsheet_fields/extra_fields for loader
-        spreadsheet_fields = row.to_dict()
-        spreadsheet_fields["Year"] = str(new_year)
-        spreadsheet_fields["URL"] = new_url
-        try:
-            valid = is_data_available(data_type, new_url, spreadsheet_fields)
-            resp_status = "OPD loader check"
-        except Exception as e:
-            if verbose:
-                print(f"Error fetching {new_url}: {e}")
-            continue
-        if valid:
-            if verbose:
-                print(f"Valid new URL found: {new_url} (status: {resp_status})")
-            # Add to OPD_Source_table
-            new_row = row.copy()
-            new_row["URL"] = new_url
-            new_row["Year"] = str(new_year)
-            new_row["last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
-            opd_df = pd.read_csv(source_table_path)
-            opd_df = pd.concat([opd_df, pd.DataFrame([new_row])], ignore_index=True)
-            opd_df.to_csv(source_table_path, index=False)
-            if verbose:
-                print(f"Added to OPD_Source_table: {new_url}")
-            new_urls.append(new_url)
-        else:
-            if verbose:
-                print(f"{new_url}: not valid (status: {resp_status})")
-    return new_urls
+        spreadsheet_fields = row._asdict()
+        # year_slice = (year_match.start(), year_match.end())
+        if year < current_year:
+            for y in range(year + 1, current_year + 1):
+                valid, new_url = find_valid_url_for_year(url, y, year_str, data_type, spreadsheet_fields)
+                if valid:
+                    # Update DataFrame directly, no need to check if already present
+                    new_row = spreadsheet_fields.copy()
+                    new_row["URL"] = new_url
+                    new_row["Year"] = str(y)
+                    new_row["last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
+                    new_row["coverage_start"] = f"01/01/{y}"
+                    if y == current_year:
+                        new_row["coverage_end"] = datetime.now().strftime("%m/%d/%Y")
+                    else:
+                        new_row["coverage_end"] = f"12/31/{y}"
+                    df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
+                    df.to_csv(OPD_SOURCE_TABLE, index=False)
+                    if verbose:
+                        print(f"Added to OPD_Source_table: {new_url}") 
+                else:
+                    if verbose:
+                        print(f"{new_url}: not valid. Skipping.")
+    return print(f"Updated {len(to_test)} sources with new URLs.") if verbose else None

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -62,7 +62,7 @@ def is_data_available(data_type, url, spreadsheet_fields):
     try:
         args = loader_info["constructor"](url, spreadsheet_fields)
         loader = loader_info["loader"](*args)
-        count = loader.get_count()
+        count = loader.get_count(force=True)
         return count > 0
     except Exception as e:
         return False

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -131,7 +131,7 @@ def try_url_years(
         raise ValueError("n_years must be an int or a range.")
     
     df = pd.read_csv(OPD_SOURCE_TABLE)
-    deleted_df = pd.read_csv(DELETED_TABLE)
+    # deleted_df = pd.read_csv(DELETED_TABLE)
     current_year = datetime.now().year    
     
     for y in years_to_try:
@@ -139,41 +139,44 @@ def try_url_years(
         # Check if URL is already in the spreadsheet
         in_spreadsheet = (df["URL"] == new_url).any()
         if in_spreadsheet:
-            idx = df.index[df["URL"] == new_url][0]
-            row = df.loc[idx]
-            # Test if still valid
-            valid, _ = find_valid_url_for_year(url, y, year_str, data_type, spreadsheet_fields)
-            if valid:
-                # Update last_coverage_check and coverage dates
-                df.at[idx, "last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
-                df.to_csv(OPD_SOURCE_TABLE, index=False)
-                if verbose:
-                    print(f"{new_url} already in spreadsheet and valid. Updated last_coverage_check.")
-                continue
-            else:
-                # Remove from spreadsheet, add to deleted
-                if verbose:
-                    print(f"{new_url} in spreadsheet but no longer valid. Removing and logging as deleted.")
-                removed_row = df.loc[[idx]].copy()
-                deleted_fields = [
-                    "OPD Status","State","SourceName","Agency","AgencyFull","TableType","Year","Error",
-                    "Date Outage Started","Last Outage Confirmation","Date Outage Ended","Date Last Contacted",
-                    "Contact Details","source-url","URL","dataset-id"
-                ]
-                # Prepare the deleted row
-                deleted_row = {f: "" for f in deleted_fields}
-                deleted_row["OPD Status"] = f"Deleted from OPD {datetime.now().strftime('%m/%d/%Y')}"
-                deleted_row["Error"] = "URL no longer valid via prediction_funcs test."
-                for col in deleted_fields:
-                    if col in removed_row.columns:
-                        deleted_row[col] = removed_row.iloc[0].get(col, "")
+            if verbose:
+                print(f"{new_url} already in spreadsheet. Skipping.")
+            continue
+            # idx = df.index[df["URL"] == new_url][0]
+            # row = df.loc[idx]
+            # # Test if still valid
+            # valid, _ = find_valid_url_for_year(url, y, year_str, data_type, spreadsheet_fields)
+            # if valid:
+            #     # Update last_coverage_check and coverage dates
+            #     df.at[idx, "last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
+            #     df.to_csv(OPD_SOURCE_TABLE, index=False)
+            #     if verbose:
+            #         print(f"{new_url} already in spreadsheet and valid. Updated last_coverage_check.")
+            #     continue
+            # else:
+            #     # Remove from spreadsheet, add to deleted
+            #     if verbose:
+            #         print(f"{new_url} in spreadsheet but no longer valid. Removing and logging as deleted.")
+            #     removed_row = df.loc[[idx]].copy()
+            #     deleted_fields = [
+            #         "OPD Status","State","SourceName","Agency","AgencyFull","TableType","Year","Error",
+            #         "Date Outage Started","Last Outage Confirmation","Date Outage Ended","Date Last Contacted",
+            #         "Contact Details","source-url","URL","dataset-id"
+            #     ]
+            #     # Prepare the deleted row
+            #     deleted_row = {f: "" for f in deleted_fields}
+            #     deleted_row["OPD Status"] = f"Deleted from OPD {datetime.now().strftime('%m/%d/%Y')}"
+            #     deleted_row["Error"] = "URL no longer valid via prediction_funcs test."
+            #     for col in deleted_fields:
+            #         if col in removed_row.columns:
+            #             deleted_row[col] = removed_row.iloc[0].get(col, "")
 
-                # Append to deleted_df and update files
-                deleted_df = pd.concat([deleted_df, pd.DataFrame([deleted_row])], ignore_index=True)
-                df = df.drop(idx)
-                df.to_csv(OPD_SOURCE_TABLE, index=False)
-                deleted_df.to_csv(DELETED_TABLE, index=False)
-                continue
+            #     # Append to deleted_df and update files
+            #     deleted_df = pd.concat([deleted_df, pd.DataFrame([deleted_row])], ignore_index=True)
+            #     df = df.drop(idx)
+            #     df.to_csv(OPD_SOURCE_TABLE, index=False)
+            #     deleted_df.to_csv(DELETED_TABLE, index=False)
+            #     continue
         else:
             valid, new_url = find_valid_url_for_year(url, y, year_str, data_type, spreadsheet_fields)
             if valid:

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -12,7 +12,7 @@ TRACKING_TABLE = Path(__file__).parent.parent.parent / "police_data_source_track
 LOADER_MAP = {  
     "arcgis": {
         "loader": Arcgis,
-        "required_fields": ["State", "SourceName", "Agency", "AgencyFull", "TableType", "DataType", "date_field"],  # date_field required if Year is MULTI
+        "required_fields": ["State", "SourceName", "Agency", "AgencyFull", "TableType", "DataType"],  # date_field required if Year is MULTI, but unlikely if URL contains year 
         "constructor": lambda url, sf: (url, sf.get("date_field"), sf.get("query"))
     },
     "carto": {
@@ -115,7 +115,7 @@ def try_url_years(
     for y in years_to_try:
         new_url = url.replace(year_str, str(y), 1)
         try:
-            valid, coverage_start, coverage_end = is_data_available(data_type, new_url, spreadsheet_fields)
+            valid = is_data_available(data_type, new_url, spreadsheet_fields)
         except Exception as e:
             if verbose:
                 print(f"Error fetching {new_url}: \n {e}")

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -278,8 +278,13 @@ def auto_update_sources(
                     df['coverage_end'] = pd.to_datetime(df['coverage_end'], errors='coerce')
 
                     sort_cols = cols.copy()
-                    sort_cols.remove('dataset_id')
+                    if 'dataset_id' in sort_cols:
+                        sort_cols.remove('dataset_id')
                     df = df.sort_values(by=sort_cols)
+
+                    # Convert back to MM/DD/YYYY string format before saving
+                    df['coverage_start'] = df['coverage_start'].dt.strftime('%m/%d/%Y')
+                    df['coverage_end'] = df['coverage_end'].dt.strftime('%m/%d/%Y')
                     df.to_csv(OPD_SOURCE_TABLE, index=False)
                     count += 1
                     if verbose:

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -274,8 +274,8 @@ def auto_update_sources(
                     cols.extend([x for x in df.columns if x not in start_cols])
                     df = df[cols]
 
-                    df['coverage_start'] = pd.to_datetime(df['coverage_start'], errors='ignore')
-                    df['coverage_end'] = pd.to_datetime(df['coverage_end'], errors='ignore')
+                    df['coverage_start'] = pd.to_datetime(df['coverage_start'], errors='coerce')
+                    df['coverage_end'] = pd.to_datetime(df['coverage_end'], errors='coerce')
 
                     sort_cols = cols.copy()
                     sort_cols.remove('dataset_id')

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -1,0 +1,186 @@
+import re
+import requests
+import pandas as pd
+from datetime import datetime, timedelta
+from pathlib import Path
+
+OPD_SOURCE_TABLE = Path(__file__).parent.parent.parent / "opd_source_table.csv"
+TRACKING_TABLE = Path(__file__).parent.parent.parent / "police_data_source_tracking.csv"
+
+def try_url_years(
+    url: str,
+    years_to_try: range = None,
+    forward: bool = False,
+    n_years: int = 5,
+    year_slice: tuple = None,
+    extra_fields: dict = None,
+    verbose: bool = True
+):
+    """
+    Try to find valid URLs by replacing a 4-digit year in the URL.
+
+    Args:
+        url (str): The URL containing a 4-digit year.
+        years_to_try (range, optional): Range of years to try. If None, uses +/- n_years from found year.
+        forward (bool, optional): If True, test forward in time. Default is False (backward).
+        n_years (int, optional): How many years to test. Default is 5.
+        year_slice (tuple, optional): (start, end) indices to extract year substring.
+        extra_fields (dict, optional): Extra fields for OPD_Source_table row.
+        verbose (bool, optional): Print progress and results.
+    Returns:
+        str or None: The first valid URL found, or None.
+    """
+    # 1. Find 4-digit year in URL
+    if year_slice:
+        year_str = url[year_slice[0]:year_slice[1]]
+        if not re.fullmatch(r"\d{4}", year_str):
+            raise ValueError("Specified slice does not contain a 4-digit year.")
+        matches = [year_str]
+    else:
+        matches = re.findall(r"\d{4}", url)
+        if len(matches) != 1:
+            raise ValueError(f"Expected exactly one 4-digit year in URL, found {len(matches)}: {matches}")
+        year_str = matches[0]
+
+    year = int(year_str)
+    if years_to_try is None:
+        if forward:
+            years_to_try = range(year + 1, year + n_years + 1)
+        else:
+            years_to_try = range(year - 1, year - n_years - 1, -1)
+
+    for y in years_to_try:
+        new_url = url.replace(year_str, str(y), 1)
+        try:
+            resp = requests.head(new_url, allow_redirects=False, timeout=10)
+        except Exception as e:
+            if verbose:
+                print(f"Error fetching {new_url}: {e}")
+            continue
+        # content_type = resp.headers.get("Content-Type", "")
+        # if resp.status_code == 200 and (
+        #     "csv" in content_type.lower() or
+        #     "excel" in content_type.lower() or
+        #     "arcgis" in new_url.lower()
+        # ):
+        if resp.status_code == 200:
+            if verbose:
+                print(f"Valid URL found: {new_url}")
+            # Prepare row for OPD_Source_table
+            fields = [
+                "State", "SourceName", "Agency", "AgencyFull", "TableType",
+                "coverage_start", "coverage_end", "last_coverage_check", "Description",
+                "source_url", "readme", "URL", "Year", "DataType", "date_field",
+                "dataset_id", "agency_field", "min_version", "query"
+            ]
+            row = {f: "" for f in fields}
+            row["URL"] = new_url
+            row["Year"] = str(y)
+            row["last_coverage_check"] = datetime.now().strftime("%d/%m/%Y")
+            if extra_fields:
+                for k, v in extra_fields.items():
+                    if k in row:
+                        row[k] = v
+            # Append to OPD_Source_table.csv
+            df = pd.read_csv(OPD_SOURCE_TABLE)
+            df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
+            df.to_csv(OPD_SOURCE_TABLE, index=False)
+            if verbose:
+                print(f"Added to OPD_Source_table: {new_url}")
+            return new_url
+        else:
+            if verbose:
+                print(f"{new_url}: status {resp.status_code}, content-type {content_type}")
+    if verbose:
+        print("No valid URL found.")
+    return None
+
+def auto_update_sources(
+    source_table_path=OPD_SOURCE_TABLE,
+    tracking_table_path=TRACKING_TABLE,
+    outdated_days=30,
+    verbose=True
+):
+    """
+    Automatically check for new data by incrementing year in URLs for testable sources.
+
+    Args:
+        source_table_path (str or Path): Path to OPD_Source_table.csv.
+        tracking_table_path (str or Path): Path to police_data_source_tracking.csv.
+        outdated_days (int): How many days before a source is considered outdated.
+        verbose (bool): Print progress and results.
+    Returns:
+        list: List of new URLs added.
+    """
+    # 1. Load tables
+    df = pd.read_csv(source_table_path)
+    tracking = pd.read_csv(tracking_table_path)
+    # 2. Filter by DataType
+    testable_types = ["CSV", "Excel", "Arcgis"]
+    df = df[df["DataType"].str.lower().isin([t.lower() for t in testable_types])]
+    # 3. Filter URLs with exactly one 4-digit year
+    df = df[df["URL"].str.contains(r"\d{4}", regex=True)]
+    df = df[df["URL"].str.count(r"\d{4}") == 1]
+    # 4. Check last checked date
+    columns_to_match = ['State', 'SourceName', 'AgencyFull', 'TableType']
+    outdated = []
+    for idx, row in df.iterrows():
+        # Find matching tracking row
+        mask = (tracking[columns_to_match] == row[columns_to_match]).all(axis=1)
+        last_checked = None
+        if mask.any():
+            last_checked = tracking.loc[mask, "last_coverage_check"].values[0]
+        if last_checked:
+            try:
+                last_checked_dt = pd.to_datetime(last_checked)
+            except Exception:
+                last_checked_dt = datetime.min
+        else:
+            last_checked_dt = datetime.min
+        if (datetime.now() - last_checked_dt).days >= outdated_days:
+            outdated.append(idx)
+    if not outdated:
+        if verbose:
+            print("No outdated sources found.")
+        return []
+    new_urls = []
+    for idx in outdated:
+        row = df.loc[idx]
+        url = row["URL"]
+        year_match = re.search(r"\d{4}", url)
+        if not year_match:
+            continue
+        year_str = year_match.group()
+        year = int(year_str)
+        # Try next year
+        new_year = year + 1
+        new_url = url.replace(year_str, str(new_year), 1)
+        try:
+            resp = requests.head(new_url, allow_redirects=False, timeout=10)
+        except Exception as e:
+            if verbose:
+                print(f"Error fetching {new_url}: {e}")
+            continue
+        content_type = resp.headers.get("Content-Type", "")
+        if resp.status_code == 200 and (
+            "csv" in content_type.lower() or
+            "excel" in content_type.lower() or
+            "arcgis" in new_url.lower()
+        ):
+            if verbose:
+                print(f"Valid new URL found: {new_url}")
+            # Add to OPD_Source_table
+            new_row = row.copy()
+            new_row["URL"] = new_url
+            new_row["Year"] = str(new_year)
+            new_row["last_coverage_check"] = datetime.now().strftime("%Y-%m-%d")
+            opd_df = pd.read_csv(source_table_path)
+            opd_df = pd.concat([opd_df, pd.DataFrame([new_row])], ignore_index=True)
+            opd_df.to_csv(source_table_path, index=False)
+            if verbose:
+                print(f"Added to OPD_Source_table: {new_url}")
+            new_urls.append(new_url)
+        else:
+            if verbose:
+                print(f"{new_url}: status {resp.status_code}, content-type {content_type}")
+    return new_urls

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -264,10 +264,7 @@ def auto_update_sources(
                     new_row["Year"] = str(y)
                     new_row["last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
                     new_row["coverage_start"] = f"01/01/{y}"
-                    if y == current_year:
-                        new_row["coverage_end"] = datetime.now().strftime("%m/%d/%Y")
-                    else:
-                        new_row["coverage_end"] = f"12/31/{y}"
+                    new_row["coverage_end"] = f"12/31/{y}"
                     df = pd.read_csv(OPD_SOURCE_TABLE)
                     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
                     df.to_csv(OPD_SOURCE_TABLE, index=False)

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -265,6 +265,8 @@ def auto_update_sources(
                     new_row["last_coverage_check"] = datetime.now().strftime("%m/%d/%Y")
                     new_row["coverage_start"] = f"01/01/{y}"
                     new_row["coverage_end"] = f"12/31/{y}"
+                    new_row["source_url"] = ""
+                    
                     df = pd.read_csv(OPD_SOURCE_TABLE)
                     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
                     # Reorder columns so columns most useful to user are up front

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -80,18 +80,24 @@ def find_valid_url_for_year(url, year, year_str, data_type, spreadsheet_fields):
 
 def try_url_years(
     url: str,
+    spreadsheet_fields: dict,
     n_years = 5,
     forward: bool = None,
     year_slice: tuple = None,
-    spreadsheet_fields: dict = None,
-    verbose: bool = False,
+    verbose: bool = False
 ):
     """
     Try to find valid URLs by replacing a 4-digit year in the URL.
+    Args:
+    url: str. The URL to modify.
+    spreadsheet_fields: dict with fields to use for checking validity and adding to OPD_Source_table.
     n_years: int or range. If int, tries n_years forward (or backward if forward=False). If range, uses as years to try.
     forward: If n_years is int, direction to try. If None, defaults to True.
+    year_slice: tuple of (start, end) to slice the URL for the year. If None, finds the first 4-digit year in the URL.
+    verbose: If True, prints progress messages.
     
-    *Assumes date fields are related to the year in the URL.
+    Attempts to find valid URLs by incrementing or decrementing the year in the URL and checking if the resulting URL is valid.
+    Updates OPD_SOURCE_TABLE and DELETED_TABLE as appropriate.
     """
     if spreadsheet_fields is None or "DataType" not in spreadsheet_fields:
         raise ValueError("spreadsheet_fields must include 'DataType' key")
@@ -148,7 +154,6 @@ def try_url_years(
                 # Remove from spreadsheet, add to deleted
                 if verbose:
                     print(f"{new_url} in spreadsheet but no longer valid. Removing and logging as deleted.")
-                # TODO - fix fields for deleted_table... *days later* I don't remember what I meant here.
                 removed_row = df.loc[[idx]].copy()
                 deleted_fields = [
                     "OPD Status","State","SourceName","Agency","AgencyFull","TableType","Year","Error",

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -71,7 +71,7 @@ def find_valid_url_for_year(url, year, year_str, data_type, spreadsheet_fields):
     """
     Returns (is_valid, new_url, coverage_start, coverage_end)
     """
-    new_url = url.replace(year_str, str(year), 1)
+    new_url = url.replace(year_str, str(year))
     try:
         valid = is_data_available(data_type, new_url, spreadsheet_fields)
     except Exception as e:

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -267,6 +267,19 @@ def auto_update_sources(
                     new_row["coverage_end"] = f"12/31/{y}"
                     df = pd.read_csv(OPD_SOURCE_TABLE)
                     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
+                    # Reorder columns so columns most useful to user are up front
+                    start_cols = ["State","SourceName","Agency","AgencyFull","TableType","coverage_start","coverage_end",
+                                "last_coverage_check",'Year','agency_originated','supplying_entity',"Description","source_url","readme","URL"]
+                    cols = start_cols.copy()
+                    cols.extend([x for x in df.columns if x not in start_cols])
+                    df = df[cols]
+
+                    df['coverage_start'] = pd.to_datetime(df['coverage_start'], errors='ignore')
+                    df['coverage_end'] = pd.to_datetime(df['coverage_end'], errors='ignore')
+
+                    sort_cols = cols.copy()
+                    sort_cols.remove('dataset_id')
+                    df = df.sort_values(by=sort_cols)
                     df.to_csv(OPD_SOURCE_TABLE, index=False)
                     count += 1
                     if verbose:

--- a/python/predict_urls/prediction_funcs.py
+++ b/python/predict_urls/prediction_funcs.py
@@ -63,8 +63,11 @@ def is_data_available(data_type, url, spreadsheet_fields):
         args = loader_info["constructor"](url, spreadsheet_fields)
         loader = loader_info["loader"](*args)
         count = loader.get_count(force=True)
-        return count > 0
+        # print(f"Data available for {url}: {count} records found.")
+        return count > 1 # Error message appears as count = 1 for CSV while testing. Didn't check other data_types
+    
     except Exception as e:
+        print(f"Exception in is_data_available for {url}: {e}")
         return False
 
 def find_valid_url_for_year(url, year, year_str, data_type, spreadsheet_fields):

--- a/python/predict_urls/requirements.txt
+++ b/python/predict_urls/requirements.txt
@@ -1,0 +1,2 @@
+openpolicedata
+pandas>=2.2.3


### PR DESCRIPTION
Closes openpolicedata/openpolicedata#244

- Adds [prediction_funcs.py](python/predict_urls/prediction_funcs.py) with two primary functions:
  1) takes a dataset URL, predicts and tests for additional yearly datasets
  2) scans the OPD source table for predictable URLs that can be tested for new year's datasets
- Adds a [notebook](python/predict_urls/predict_urls.ipynb) to assist function use
- Adds [requirements.txt](python/predict_urls/requirements.txt) for function use